### PR TITLE
https is the new default

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,8 +21,8 @@
 
 # gem_package sources
 if node['rubygems']['gem_disable_default'] then
-  execute "gem sources --remove http://rubygems.org" do
-    only_if "gem sources --list | grep 'http://rubygems.org'"
+  execute "gem sources --remove https://rubygems.org" do
+    only_if "gem sources --list | grep 'https://rubygems.org'"
   end.run_action(:run)
 end
 
@@ -34,8 +34,8 @@ end
 
 # chef_gem sources
 if node['rubygems']['chef_gem_disable_default'] then
-  execute "/opt/chef/embedded/bin/gem sources --remove http://rubygems.org/" do
-    only_if "gem sources --list | grep 'http://rubygems.org'"
+  execute "/opt/chef/embedded/bin/gem sources --remove https://rubygems.org/" do
+    only_if "gem sources --list | grep 'https://rubygems.org'"
   end.run_action(:run)
 end
 


### PR DESCRIPTION
according to http://guides.rubygems.org/command-reference/#gem-sources https://rubygems.org is the new default, replacing the old http://rubygems.org
