### PR TITLE
Fix requirements information for Chef Version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ gems on [rubygems.org](https://rubygems.org).
 
 Requirements
 ============
-Omnibus Chef 12.8.1 or above
+Omnibus Chef 12.5.1 or above
 
 Usage
 =====

--- a/Rakefile
+++ b/Rakefile
@@ -65,7 +65,12 @@ namespace :supermarket do
     require "stove/rake_task"
 
     desc "Publish cookbook to Supermarket with Stove"
-    Stove::RakeTask.new
+    Stove::RakeTask.new do |t|
+      t.stove_opts = [].tap do |a|
+        a.push("--sign")
+        a.push("--extended-metadata")
+      end
+    end
   rescue LoadError => e
     puts ">>> Gem load error: #{e}, omitting #{task.name}" unless ENV["CI"]
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "Ryan Hass <rhass+community-cookbooks@chef.io>"
 license          "Apache-2.0"
 description      "Configures rubygems and bundler"
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
-version          "1.0.0"
+version          "1.0.1"
 
 supports "amazon"
 supports "centos"


### PR DESCRIPTION
This fixes the version requirements for the Chef version and updates the Rake supermarket publish task to GPG sign release tags.

@chef-cookbooks/engineering-services 
