### PR TITLE
Do not attempt to manage home directories.

### DIFF
--- a/resources/gemrc.rb
+++ b/resources/gemrc.rb
@@ -46,6 +46,7 @@ action :create do
     user new_resource.user if new_resource.property_is_set?("user")
     group new_resource.group if new_resource.property_is_set?("group")
     recursive true
+    not_if { new_resource.name == :local || new_resource.name == "local" }
   end
 
   file path do

--- a/resources/gemrc.rb
+++ b/resources/gemrc.rb
@@ -46,7 +46,7 @@ action :create do
     user new_resource.user if new_resource.property_is_set?("user")
     group new_resource.group if new_resource.property_is_set?("group")
     recursive true
-    not_if { new_resource.name == :local || new_resource.name == "local" }
+    not_if { new_resource.name.to_sym == :local }
   end
 
   file path do
@@ -59,10 +59,10 @@ end
 private
 
 def coerce_path(value)
-  case value
-  when :local, "local"
+  case value.to_sym
+  when :local
     ::File.join(Dir.home, ".gemrc")
-  when :global, "global"
+  when :global
     Gem::ConfigFile::SYSTEM_WIDE_CONFIG_FILE
   else
     value

--- a/test/spec/default_spec.rb
+++ b/test/spec/default_spec.rb
@@ -13,15 +13,21 @@ describe "rubygems::default" do
       ).converge(described_recipe)
     end
 
-    context "a .gemrc file in the home directory" do
-      it "is created" do
-        expect(chef_run).to create_file(gemrc)
-        expect(chef_run).to create_file(global_gemrc)
+    context "home directory" do
+      it "is not created or modified by this resource" do
+        expect(chef_run).not_to create_directory(::File.dirname(gemrc))
       end
 
-      it "contains the custom source" do
-        expect(chef_run).to render_file(gemrc).with_content("https://rubygems.org")
-        expect(chef_run).to render_file(global_gemrc).with_content("https://rubygems.org")
+      context ".gemrc file" do
+        it "is created" do
+          expect(chef_run).to create_file(gemrc)
+          expect(chef_run).to create_file(global_gemrc)
+        end
+
+        it "contains the default rubygems URL" do
+          expect(chef_run).to render_file(gemrc).with_content("https://rubygems.org")
+          expect(chef_run).to render_file(global_gemrc).with_content("https://rubygems.org")
+        end
       end
     end
   end
@@ -46,13 +52,14 @@ describe "rubygems::default" do
       end.converge(described_recipe)
     end
 
-    context "a .gemrc file in the home directory" do
-      it "contains the custom source" do
-        expect(chef_run).to render_file(gemrc).with_content("http://localhost:9292")
-        expect(chef_run).to render_file(global_gemrc).with_content("https://rubygems.org")
+    context "home directory" do
+      context ".gemrc file" do
+        it "contains the custom source" do
+          expect(chef_run).to render_file(gemrc).with_content("http://localhost:9292")
+          expect(chef_run).to render_file(global_gemrc).with_content("https://rubygems.org")
+        end
       end
     end
-
   end
 
   context "with default sources disabled" do


### PR DESCRIPTION
This resolves a bug in the `gemrc` provider when using `name :local` or `gemrc "local"` in which the resource could potentially recursively change file permissions for the home directory. We now skip the
`directory` resource call within the `gemrc` custom resource when the gemrc resource name resolves to either `:local` or `"local"` to ensure files and directories do not become tainted when the user or group
values are set.

Additionally, this cleans up the chefspec slightly and adds a context to make it a little cleaner.

/cc @chef-cookbooks/engineering-services @tas50 
