### PR TITLE
Fix gemrc error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,12 @@
 
 source 'https://rubygems.org'
 
-gem 'tomlrb'
-gem 'rake'
-gem 'stove'
+gem 'berkshelf'
+gem 'chefspec'
 gem 'community_cookbook_releaser'
+gem 'cookstyle'
+gem 'foodcritic'
+gem 'rake'
+gem 'rspec'
+gem 'stove'
+gem 'tomlrb'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,7 +31,7 @@ end
 gemrc 'local_gem_sources' do
   name :local
   values(
-    sources: node['rubygems']['gem_sources']
+    sources: node['rubygems']['gem_sources'].to_a
   )
 end
 
@@ -47,6 +47,6 @@ end
 gemrc 'chef_gem_sources' do
   name :global
   values(
-    sources: node['rubygems']['chef_gem_sources']
+    sources: node['rubygems']['chef_gem_sources'].to_a
   )
 end


### PR DESCRIPTION
### Description
When using this cookbook like so (tested with Chef 12.12.15)
```
"default_attributes": {
  "rubygems": {
    "gem_sources": [
      "https://rubygems.org",
      "https://path_to/my_internal/rubygems/"
    ]
  },
  ...
```
the cookbook is generating the .gemrc file incorrectly.
Here are the contents of `/root/.gemrc`
```
---
sources:
- https://rubygems.org
:sources: !ruby/array:Chef::Node::ImmutableArray
- https://rubygems.org
- https://path_to/my_internal/rubygems/
```

Can see that it is injecting `!ruby/array:Chef::Node::ImmutableArray`.  Using `to_a` fixes the issue.

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes testing.
- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
